### PR TITLE
add screen adaptive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,25 @@
 import myFunc from './js/onLigthButtonClick';
 import onResize from './js/resize';
-const mediaQueryList = window.matchMedia('screen and (min-width: 768px) and (max-width: 1200px)');
-console.log(mediaQueryList)
+const screen = {
+  mobile : window.matchMedia( '(min-width: 480px)' ),
+  tablet: window.matchMedia('(min-width: 768px)'),
+  desktop: window.matchMedia('(min-width: 1200px)'),
+};
 
-mediaQueryList.addEventListener('change', onResize)
+for (let [scr, mq] of Object.entries(screen)) {
+  if (mq) mq.addEventListener('change', mqHandler);
+}
+
+function mqHandler() {
+  let size = null;
+  let toRemove = [];
+  for (let [scr, mq] of Object.entries(screen)) {
+    if (!mq || mq.matches) {
+      size = scr;
+    } else if (scr !== size) toRemove.push(scr);
+  }
+
+  onResize(size, toRemove);
+  
+}
+

--- a/src/js/resize.js
+++ b/src/js/resize.js
@@ -1,17 +1,10 @@
 import { refs } from './refs';
-export default function onResize(mql) {
-    if (mql.matches) {
-    
-    refs.item.forEach(singleItem => {
-        singleItem.classList.add('gallery__item-tablet');
-        singleItem.classList.remove('gallery__item-desktop');
-    })
-  } else {
-      refs.item.forEach(singleItem => {
-          singleItem.classList.remove('gallery__item-tablet');
-          singleItem.classList.add('gallery__item-desktop');
-      })
-  }
-
- 
+export default function onResize(size, toRemove) {
+  refs.item.forEach(singleItem => {
+    for (sizeRemove of toRemove) {
+      singleItem.classList.remove(`gallery__item-${sizeRemove}`);
+    }
+    singleItem.classList.add(`gallery__item-${size}`);
+  });
+  
 }

--- a/src/sass/components/_gallery.scss
+++ b/src/sass/components/_gallery.scss
@@ -35,6 +35,7 @@
 }
 
 .gallery__item-tablet {
+ 
     width: calc((100% - 30px) / 2);
 }
 


### PR DESCRIPTION
 Для адаптивних елементів - необхідно вказувати класи для tablet і desktop наступним чином:  .gallery__item - це клас за замовчуванням, тобто mobile. Далі - .gallery__item-tablet і .gallery__item-desktop - відповідно стилі для планшета і десктоп. Скрипт буде динамічно підставляти класи по шаблону, додаючи до назви класу tablet або desktop

Для функціонування:
Додати елемент у об'єкт refs у файлі refs.js (якщо елементів декілька, наприклад li у списку, потрібно querySelectorAll, і не забути потім зробити перебирання усіх елементів forEach)
у функцію resize додати elemetn.classList.add('class')
для видалення класів - доповнити:
for (sizeRemove of toRemove) {
singleItem.classList.remove(`gallery__item-${sizeRemove}`);
}
параметр toRemove - це масив з розмірами екрану, які треба прибрати. (edited) 